### PR TITLE
Use one SwiftData and CloudKit configuration

### DIFF
--- a/FinanceTracker/Helpers/AppConfiguration.swift
+++ b/FinanceTracker/Helpers/AppConfiguration.swift
@@ -61,7 +61,7 @@ class AppConfiguration {
         static let needsPercent = "needsPercent"
         static let wantsPercent = "wantsPercent"
         static let savingsPercent = "savingsPercent"
-        static let isCloudSyncEnabled = "isCloudSyncEnabled"
+        static let isCloudSyncEnabled = SageModelContainer.cloudKitPreferenceKey
         static let hasCompletedSetup = "hasCompletedSetup"
         static let smartTaggingMode = "smartTaggingMode"
         static let needsColor = "categoryColorNeeds"
@@ -113,7 +113,7 @@ class AppConfiguration {
     
     var isCloudSyncEnabled: Bool {
         didSet {
-            defaults.set(isCloudSyncEnabled, forKey: Keys.isCloudSyncEnabled)
+            SageModelContainer.setCloudKitPreference(isCloudSyncEnabled)
             cloudKVS.set(isCloudSyncEnabled, forKey: Keys.isCloudSyncEnabled)
             cloudKVS.synchronize()
         }

--- a/FinanceTracker/SageApp.swift
+++ b/FinanceTracker/SageApp.swift
@@ -24,6 +24,10 @@ struct SageApp: App {
         // Pull latest iCloud KVS values before checking setup state
         NSUbiquitousKeyValueStore.default.synchronize()
 
+        // Keep the store configuration stable across the app, widgets, and App Intents until
+        // the next app launch.
+        SageModelContainer.activateCloudKitPreference()
+
         // Present notifications that fire while the app is foreground
         UNUserNotificationCenter.current().delegate = NotificationDelegate.shared
 

--- a/FinanceTracker/SageAppContainer.swift
+++ b/FinanceTracker/SageAppContainer.swift
@@ -8,81 +8,16 @@ import Foundation
 import SwiftData
 import SageKit
 
-// Copies SQLite files (main + WAL + SHM) from src to dst. Safe to call if src doesn't exist.
-private func copyStoreFiles(from src: URL, to dst: URL) {
-    let fm = FileManager.default
-    for suffix in ["", "-wal", "-shm"] {
-        let srcFile = URL(fileURLWithPath: src.path + suffix)
-        let dstFile = URL(fileURLWithPath: dst.path + suffix)
-        guard fm.fileExists(atPath: srcFile.path) else { continue }
-        try? fm.copyItem(at: srcFile, to: dstFile)
-    }
-}
-
-// Migrates the store from the app's private sandbox to the shared app group container.
-// Only runs once, tracked by a flag in the app group UserDefaults. Production only —
-// the DEBUG store has always lived in the app group as SageDev.sqlite.
-private func migrateStoreToAppGroupIfNeeded(destination: URL) {
-    let defaults = UserDefaults(suiteName: "group.me.enzottic.SageAppGroup")
-    let migrationKey = "hasCompletedStoreMigration"
-    guard !(defaults?.bool(forKey: migrationKey) ?? false) else { return }
-    defer { defaults?.set(true, forKey: migrationKey) }
-
-    let fm = FileManager.default
-    // Only migrate if new store doesn't exist yet — avoids clobbering a store already opened there
-    guard !fm.fileExists(atPath: destination.path) else { return }
-
-    // CloudKit will re-sync all data to the new location — no need to copy stale local files,
-    // and doing so can confuse CloudKit's change tracking metadata.
-    let cloudSyncEnabled = (UserDefaults(suiteName: "group.me.enzottic.SageAppGroup")?.bool(forKey: "isCloudSyncEnabled")) ?? false
-    guard !cloudSyncEnabled else { return }
-
-    // SwiftData's default name when no url is given varies; try the most common candidates
-    let candidates = [
-        URL.applicationSupportDirectory.appending(path: "default.store"),
-        URL.applicationSupportDirectory.appending(path: "Sage.store"),
-        URL.applicationSupportDirectory.appending(path: "FinanceTracker.store"),
-    ]
-
-    for candidate in candidates where fm.fileExists(atPath: candidate.path) {
-        copyStoreFiles(from: candidate, to: destination)
-        return
-    }
-}
-
 @MainActor
 let appContainer: ModelContainer = {
-    do {
-        #if !DEBUG
-        // iCloud KVS is authoritative for the sync preference
-        let cloudKVS = NSUbiquitousKeyValueStore.default
-        let cloudSyncEnabled: Bool
-        if cloudKVS.object(forKey: "isCloudSyncEnabled") != nil {
-            cloudSyncEnabled = cloudKVS.bool(forKey: "isCloudSyncEnabled")
-        } else {
-            let defaults = UserDefaults(suiteName: "group.me.enzottic.SageAppGroup")
-            cloudSyncEnabled = defaults?.bool(forKey: "isCloudSyncEnabled") ?? false
-        }
+    let modelContainer = SageModelContainer.shared
 
-        let groupURL = FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: SageModelContainer.appGroupIdentifier)!
-        let storeURL = groupURL.appending(path: "Sage.sqlite")
-        migrateStoreToAppGroupIfNeeded(destination: storeURL)
-        #else
-        let cloudSyncEnabled = false
-        #endif
+    #if !DEBUG
+    let recurringService = RecurringExpenseService(modelContext: modelContainer.mainContext)
+    recurringService.generateAllExpenses(through: Date())
+    #endif
 
-        let modelContainer = try SageModelContainer.make(cloudKitEnabled: cloudSyncEnabled)
-
-        #if !DEBUG
-        let recurringService = RecurringExpenseService(modelContext: modelContainer.mainContext)
-        recurringService.generateAllExpenses(through: Date())
-        #endif
-
-        return modelContainer
-    } catch {
-        fatalError("Failed to create model container: \(error)")
-    }
+    return modelContainer
 }()
 
 @MainActor

--- a/FinanceTracker/Views/DashboardView/DashboardView.swift
+++ b/FinanceTracker/Views/DashboardView/DashboardView.swift
@@ -97,7 +97,7 @@ func expenseQuery(for month: Date, limit: Int? = nil) -> Query<Expense, [Expense
 
 func expenseQuery(start: Date, end: Date, limit: Int? = nil) -> Query<Expense, [Expense]> {
     var descriptor = FetchDescriptor<Expense>(
-        predicate: #Predicate { $0.date > start && $0.date < end },
+        predicate: #Predicate { $0.date >= start && $0.date < end },
         sortBy: [SortDescriptor(\.date, order: .reverse)]
     )
     descriptor.fetchLimit = limit

--- a/FinanceTracker/Views/SettingsView/Components/ExpenseBackupSettingsSection.swift
+++ b/FinanceTracker/Views/SettingsView/Components/ExpenseBackupSettingsSection.swift
@@ -51,7 +51,7 @@ struct ExpenseBackupSettingsSection: View {
             } header: {
                 Text("iCloud Sync")
             } footer: {
-                Text("Sync your expenses across all your Apple devices.")
+                Text("Changes take effect the next time you open the app.")
             }
 
             Section {

--- a/FinanceTracker/Views/WelcomeView.swift
+++ b/FinanceTracker/Views/WelcomeView.swift
@@ -352,7 +352,7 @@ struct WelcomeView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Enable iCloud Sync")
                             .font(.headline)
-                        Text("You can change this later in Settings")
+                        Text("Your choice takes effect the next time you open the app")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/SageKit/AppIntents/Entities/ExpenseTagEntity.swift
+++ b/SageKit/AppIntents/Entities/ExpenseTagEntity.swift
@@ -26,22 +26,22 @@ public struct ExpenseTagEntity: AppEntity {
     }
 }
 
+@MainActor
 public struct ExpenseTagEntityQuery: EntityQuery {
+    @Dependency
+    var expenseStore: ExpenseStore
+
     public func entities(for identifiers: [UUID]) async throws -> [ExpenseTagEntity] {
-        let container = try SageModelContainer.make()
-        let context = ModelContext(container)
-        let all = try context.fetch(FetchDescriptor<ExpenseTag>())
+        let all = try expenseStore.context.fetch(FetchDescriptor<ExpenseTag>())
         return all
             .filter { identifiers.contains($0.id) }
             .map { ExpenseTagEntity(id: $0.id, name: $0.name, emoji: $0.emoji, symbolName: $0.symbolName) }
     }
 
     public func suggestedEntities() async throws -> [ExpenseTagEntity] {
-        let container = try SageModelContainer.make()
-        let context = ModelContext(container)
-        let all = try context.fetch(FetchDescriptor<ExpenseTag>(sortBy: [SortDescriptor(\.name)]))
+        let all = try expenseStore.context.fetch(FetchDescriptor<ExpenseTag>(sortBy: [SortDescriptor(\.name)]))
         return all.map { ExpenseTagEntity(id: $0.id, name: $0.name, emoji: $0.emoji, symbolName: $0.symbolName) }
     }
     
-    public init() { }
+    public nonisolated init() { }
 }

--- a/SageKit/AppIntents/Intents/FindExpensesIntent.swift
+++ b/SageKit/AppIntents/Intents/FindExpensesIntent.swift
@@ -75,6 +75,9 @@ public struct FindExpensesIntent: AppIntent {
     @Parameter(title: "Category") public var category: ExpenseCategory?
     @Parameter(title: "Name Contains") public var nameFilter: String?
 
+    @Dependency
+    var expenseStore: ExpenseStore
+
     public static var parameterSummary: some ParameterSummary {
         Summary("How much did I spend \(\.$timePeriod)?") {
             \.$tag
@@ -87,9 +90,8 @@ public struct FindExpensesIntent: AppIntent {
     
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<Double> {
-        let store = ExpenseStore.shared
         let (start, end) = timePeriod.dateRange
-        var expenses = store.fetchExpenses(from: start, to: end)
+        var expenses = expenseStore.fetchExpenses(from: start, to: end)
 
         if let tag {
             expenses = expenses.filter { ($0.tags ?? []).contains { $0.id == tag.id } }

--- a/SageKit/AppIntents/Intents/GetBudgetRemainingIntent.swift
+++ b/SageKit/AppIntents/Intents/GetBudgetRemainingIntent.swift
@@ -12,6 +12,9 @@ public struct GetBudgetRemainingIntent: AppIntent {
 
     @Parameter(title: "Category") public var category: ExpenseCategory?
 
+    @Dependency
+    var expenseStore: ExpenseStore
+
     public static var parameterSummary: some ParameterSummary {
         Summary("How much budget do I have left?") {
             \.$category
@@ -22,16 +25,15 @@ public struct GetBudgetRemainingIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        let store = ExpenseStore.shared
         if let category {
-            let remaining = try store.remainingBudget(for: category)
+            let remaining = try expenseStore.remainingBudget(for: category)
             if remaining >= 0 {
                 return .result(dialog: "You have \(remaining.currencyString) remaining in your \(category.rawValue.lowercased()) budget.")
             } else {
                 return .result(dialog: "You're \((-remaining).currencyString) over your \(category.rawValue.lowercased()) budget.")
             }
         } else {
-            let remaining = try store.totalRemainingBudget()
+            let remaining = try expenseStore.totalRemainingBudget()
             if remaining >= 0 {
                 return .result(dialog: "You have \(remaining.currencyString) left across all budgets this month.")
             } else {

--- a/SageKit/AppIntents/Intents/GetMonthlySpendingIntent.swift
+++ b/SageKit/AppIntents/Intents/GetMonthlySpendingIntent.swift
@@ -15,6 +15,9 @@ public struct GetMonthlySpendingIntent: AppIntent {
     @Parameter(title: "Category") public var category: ExpenseCategory?
     @Parameter(title: "Tag") public var tag: ExpenseTagEntity?
 
+    @Dependency
+    var expenseStore: ExpenseStore
+
     public static var parameterSummary: some ParameterSummary {
         Summary("How much have I spent this month?") {
             \.$category
@@ -26,15 +29,13 @@ public struct GetMonthlySpendingIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        let store = ExpenseStore.shared
-        
-        if let tag, let total = try? store.monthlyTotal(tagId: tag.id) {
+        if let tag, let total = try? expenseStore.monthlyTotal(tagId: tag.id) {
             return .result(dialog: "You've spent \(total.currencyString) on \(tag.name.lowercased()) this month.")
-        } else if let category, let total = try? store.monthlyTotal(category: category) {
+        } else if let category, let total = try? expenseStore.monthlyTotal(category: category) {
             return .result(dialog: "You've spent \(total.currencyString) on \(category.rawValue.lowercased()) this moonth.")
         }
         
-        if let total = try? store.monthlyTotal() {
+        if let total = try? expenseStore.monthlyTotal() {
             return .result(dialog: "You've spent \(total.currencyString) this month.")
         }
         

--- a/SageKit/Services/ExpenseStore.swift
+++ b/SageKit/Services/ExpenseStore.swift
@@ -10,18 +10,14 @@ import SwiftData
 
 @MainActor @Observable
 final public class ExpenseStore {
-    public static let shared = ExpenseStore()
+    public static let shared = ExpenseStore(modelContainer: SageModelContainer.shared)
     
     let modelContainer: ModelContainer
     var context: ModelContext
 
-    private init() {
-        guard let container = try? SageModelContainer.make() else {
-            fatalError("Failed to create the model container")
-        }
-        
-        self.modelContainer = container
-        self.context = container.mainContext
+    private init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        self.context = modelContainer.mainContext
     }
 
     // MARK: - Create

--- a/SageKit/Services/SageModelContainer.swift
+++ b/SageKit/Services/SageModelContainer.swift
@@ -10,8 +10,43 @@ import SwiftData
 
 public enum SageModelContainer {
     public nonisolated static let appGroupIdentifier = "group.me.enzottic.SageAppGroup"
+    public nonisolated static let cloudKitPreferenceKey = "isCloudSyncEnabled"
+    private nonisolated static let activeCloudKitPreferenceKey = "activeCloudSyncEnabled"
 
-    public static nonisolated func make(cloudKitEnabled: Bool = false) throws -> ModelContainer {
+    /// The CloudKit setting used by every process that opens the shared store.
+    ///
+    /// The user-facing preference is copied to this value when the main app launches. Keeping
+    /// the active value stable until the next launch prevents a widget or App Intent from opening
+    /// the store with a different configuration while the app is still running.
+    public nonisolated static var isCloudKitEnabled: Bool {
+        let defaults = UserDefaults(suiteName: appGroupIdentifier)
+        if defaults?.object(forKey: activeCloudKitPreferenceKey) != nil {
+            return defaults?.bool(forKey: activeCloudKitPreferenceKey) ?? false
+        }
+        return defaults?.bool(forKey: cloudKitPreferenceKey) ?? false
+    }
+
+    public nonisolated static func setCloudKitPreference(_ enabled: Bool) {
+        UserDefaults(suiteName: appGroupIdentifier)?.set(enabled, forKey: cloudKitPreferenceKey)
+    }
+
+    /// Applies the requested setting before the main app opens the store.
+    public nonisolated static func activateCloudKitPreference() {
+        let defaults = UserDefaults(suiteName: appGroupIdentifier)
+        let requestedValue = defaults?.bool(forKey: cloudKitPreferenceKey) ?? false
+        defaults?.set(requestedValue, forKey: activeCloudKitPreferenceKey)
+    }
+
+    @MainActor
+    public static let shared: ModelContainer = {
+        do {
+            return try make()
+        } catch {
+            fatalError("Failed to create the Sage model container: \(error)")
+        }
+    }()
+
+    private static nonisolated func make() throws -> ModelContainer {
         UIColorValueTransformer.register()
 
         let schema = Schema(versionedSchema: SageSchemaV4.self)
@@ -26,10 +61,12 @@ public enum SageModelContainer {
             cloudKitDatabase: .none
         )
         #else
+        let storeURL = groupURL.appending(path: "Sage.sqlite")
+        migrateStoreToAppGroupIfNeeded(destination: storeURL)
         let config = ModelConfiguration(
             schema: schema,
-            url: groupURL.appending(path: "Sage.sqlite"),
-            cloudKitDatabase: cloudKitEnabled ? .automatic : .none
+            url: storeURL,
+            cloudKitDatabase: isCloudKitEnabled ? .automatic : .none
         )
         #endif
 
@@ -44,6 +81,33 @@ public enum SageModelContainer {
         #endif
 
         return container
+    }
+
+    private static nonisolated func migrateStoreToAppGroupIfNeeded(destination: URL) {
+        let defaults = UserDefaults(suiteName: appGroupIdentifier)
+        let migrationKey = "hasCompletedStoreMigration"
+        guard !(defaults?.bool(forKey: migrationKey) ?? false) else { return }
+        defer { defaults?.set(true, forKey: migrationKey) }
+
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: destination.path), !isCloudKitEnabled else { return }
+
+        let candidates = [
+            URL.applicationSupportDirectory.appending(path: "default.store"),
+            URL.applicationSupportDirectory.appending(path: "Sage.store"),
+            URL.applicationSupportDirectory.appending(path: "FinanceTracker.store"),
+        ]
+
+        guard let source = candidates.first(where: { fileManager.fileExists(atPath: $0.path) }) else {
+            return
+        }
+
+        for suffix in ["", "-wal", "-shm"] {
+            let sourceFile = URL(fileURLWithPath: source.path + suffix)
+            guard fileManager.fileExists(atPath: sourceFile.path) else { continue }
+            let destinationFile = URL(fileURLWithPath: destination.path + suffix)
+            try? fileManager.copyItem(at: sourceFile, to: destinationFile)
+        }
     }
 
     /// Migrates legacy single-tag data into the V3 `tags` array.


### PR DESCRIPTION
## Summary

- centralize persistent `ModelContainer` creation in SageKit so the app, widgets, and App Intents use the same configuration
- inject the shared expense store into App Intents and tag queries instead of opening independent containers
- keep the active CloudKit setting stable across processes until the next app launch
- move legacy store migration into the shared factory and explain relaunch behavior in onboarding and Settings

## Tests

- `xcodebuild build -project FinanceTracker.xcodeproj -scheme FinanceTracker -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/sage-issue-20-derived CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project FinanceTracker.xcodeproj -scheme FinanceTracker -configuration Release -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/sage-issue-20-release-derived CODE_SIGNING_ALLOWED=NO`

Both builds passed. Device CloudKit migration and end-to-end sync need a signed iCloud test environment.

Closes #20