### PR TITLE
Remove sensitive production logs

### DIFF
--- a/FinanceTracker/Services/ExpenseBackupService.swift
+++ b/FinanceTracker/Services/ExpenseBackupService.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import OSLog
 import SageKit
 
 final class ExpenseBackupService {
     static let shared = ExpenseBackupService()
+    private let logger = Logger(subsystem: "me.enzottic.FinanceTracker", category: "ExpenseBackup")
 
     func exportExpenses(expenses: [Expense]) -> Result<String, ExpenseExportServiceError> {
         do {
@@ -25,10 +27,10 @@ final class ExpenseBackupService {
             }
             try csvData.write(to: fileURL, options: .atomic)
             
-            print("File saved successfully at: \(fileURL.path)")
+            logger.info("Expense export completed.")
             
         } catch {
-            print("Error: \(error.localizedDescription)")
+            logger.error("Expense export failed: \(error.localizedDescription, privacy: .private(mask: .hash))")
             return .failure(.filesystemError("Error saving file: \(error.localizedDescription)"))
         }
         

--- a/FinanceTrackerShareExtension/ShareViewController.swift
+++ b/FinanceTrackerShareExtension/ShareViewController.swift
@@ -18,16 +18,11 @@ class ShareViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        log.info("viewDidAppear — starting handleIncomingImage")
         Task { await handleIncomingImage() }
     }
 
     @MainActor
     private func handleIncomingImage() async {
-        log.info("handleIncomingImage called")
-        log.info("extensionContext: \(self.extensionContext != nil ? "present" : "nil")")
-        log.info("inputItems count: \(self.extensionContext?.inputItems.count ?? -1)")
-
         guard
             let item = extensionContext?.inputItems.first as? NSExtensionItem,
             let provider = item.attachments?.first(where: {
@@ -38,11 +33,8 @@ class ShareViewController: UIViewController {
             return finish()
         }
 
-        log.info("Image provider found, loading item...")
-
         do {
             let loaded = try await provider.loadItem(forTypeIdentifier: UTType.image.identifier)
-            log.info("Loaded item type: \(String(describing: type(of: loaded)))")
 
             let image: UIImage? = switch loaded {
                 case let img as UIImage: img
@@ -56,19 +48,16 @@ class ShareViewController: UIViewController {
                 return finish()
             }
 
-            log.info("Image loaded: \(image.size.width)x\(image.size.height)")
-
             do {
                 try saveImageToAppGroup(image)
-                log.info("Image saved to app group successfully")
             } catch {
-                log.error("saveImageToAppGroup failed: \(error)")
+                log.error("Could not save shared receipt image: \(error.localizedDescription, privacy: .private(mask: .hash))")
                 return finish()
             }
 
             openMainApp()
         } catch {
-            log.error("loadItem failed: \(error)")
+            log.error("Could not load shared receipt image: \(error.localizedDescription, privacy: .private(mask: .hash))")
             finish()
         }
     }
@@ -77,15 +66,12 @@ class ShareViewController: UIViewController {
         let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: "group.me.enzottic.SageAppGroup"
         )
-        log.info("App group container URL: \(containerURL?.path ?? "NIL — app group not configured")")
-
         guard let containerURL, let data = image.jpegData(compressionQuality: 0.8) else {
             throw URLError(.badURL)
         }
 
         let fileURL = containerURL.appendingPathComponent("pendingReceiptImage.jpg")
         try data.write(to: fileURL)
-        log.info("Wrote \(data.count) bytes to \(fileURL.path)")
     }
 
     @MainActor
@@ -100,8 +86,6 @@ class ShareViewController: UIViewController {
             finish()
             return
         }
-        log.info("Attempting to open \(url.absoluteString) via extensionContext")
-
         var responder: UIResponder? = self
         while responder != nil {
             if let application = responder as? UIApplication {
@@ -114,7 +98,6 @@ class ShareViewController: UIViewController {
     }
 
     private func finish() {
-        log.info("finish() called — completing extension request")
         extensionContext?.completeRequest(returningItems: nil)
     }
 }

--- a/SageKit/Services/SageModelContainer.swift
+++ b/SageKit/Services/SageModelContainer.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import SwiftData
 
 public enum SageModelContainer {
@@ -23,6 +24,7 @@ public enum SageModelContainer {
     public nonisolated static let appGroupIdentifier = "group.me.enzottic.SageAppGroup"
     public nonisolated static let cloudKitPreferenceKey = "isCloudSyncEnabled"
     private nonisolated static let activeCloudKitPreferenceKey = "activeCloudSyncEnabled"
+    private nonisolated static let logger = Logger(subsystem: "me.enzottic.SageKit", category: "ModelContainer")
 
     /// The CloudKit setting used by every process that opens the shared store.
     ///
@@ -166,7 +168,7 @@ public enum SageModelContainer {
                 try context.save()
             }
         } catch {
-            print("Multi-tag backfill failed: \(error)")
+            logger.error("Multi-tag backfill failed: \(error.localizedDescription, privacy: .private(mask: .hash))")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace expense export and model migration print calls with redacted Logger diagnostics.
- Remove share extension logs that expose receipt image paths and metadata.
- Keep receipt-related failure diagnostics private and hashed.

## Validation
- Ran git diff --check.
- Scanned Release source: no print, NSLog, or os_log calls; no log fields contain CSV, OCR, expense, note, receipt, or account data.
- Xcode build and tests were not run because this repository has no command-line build or test setup.

Closes #25