### PR TITLE
Implement explicit recurring schedule edits

### DIFF
--- a/APP_STORE_READINESS.md
+++ b/APP_STORE_READINESS.md
@@ -254,10 +254,28 @@ distribution, and App Store Connect checks remain open without execution evidenc
   Sources: [expense creation](FinanceTracker/Views/Components/AddExpenseView.swift),
   [expense form](FinanceTracker/Views/Components/ExpenseInfoForm.swift).
 
-- [ ] **Make the recurring start-date presentation honest.** The editor passes
-  `.constant(rule.startDate)` to an interactive date picker. Show a read-only
-  value or implement a real schedule-edit operation with explicit semantics.
-  Source: [rule editor](FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift).
+- [x] **Make the recurring start-date presentation honest.** (#59) The editor
+  stages start-date changes and confirms start/frequency edits before
+  applying `editSchedule`. Existing expenses and occurrence keys are preserved.
+  Edits automatically capture the current time zone without exposing a selector
+  and use a fixed Gregorian schedule. They skip catch-up through the latest of save
+  time, the previous cursor/boundary and recorded occurrence identities, and reset
+  the cursor to follow the new start's cadence. Monthly rules resume after the
+  boundary month; daily/weekly/biweekly rules take the first anchored occurrence
+  after the boundary. A start beyond the boundary remains the first occurrence.
+  End dates before the start are rejected; an end before the next occurrence
+  leaves the rule inactive. End-only edits retain the current cadence and catch-up
+  behavior. Cancel/discard leaves the stored rule unchanged.
+  Evidence: recurrence and reminder-plan suites passed (39 tests on iOS 26.5),
+  covering persistence, preserved history, all frequencies, future starts,
+  invalid ends, monotonic boundaries, and idempotent generation. A focused
+  simulator UI test passed for confirmation, save/reopen, and removed time-zone
+  controls.
+  Source: [rule editor](FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift),
+  [schedule operation](SageKit/Services/RecurringExpenseSchedule.swift),
+  [tests](FinanceTrackerTests/RecurringExpenseServiceTests.swift).
+  Multi-device concurrent edits and older-client compatibility still require
+  device validation; older clients do not honor the schedule boundary.
 
 ## Priority 2: Polish And Accessibility
 

--- a/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
+++ b/FinanceTracker/Views/SettingsView/Components/EditRecurringRuleSheet.swift
@@ -18,11 +18,10 @@ struct EditRecurringRuleSheet: View {
     @State private var note: String
     @State private var category: ExpenseCategory
     @State private var tags: [ExpenseTag]
+    @State private var startDate: Date
     @State private var frequency: RecurrenceFrequency
     @State private var hasEndDate: Bool
     @State private var endDate: Date
-    @State private var useFixedSchedule = false
-    @State private var timeZoneIdentifier: String
     @State private var showScheduleConfirmation = false
 
     @State private var showError = false
@@ -36,79 +35,67 @@ struct EditRecurringRuleSheet: View {
         _note = State(initialValue: rule.note)
         _category = State(initialValue: rule.category)
         _tags = State(initialValue: rule.tags ?? [])
+        _startDate = State(initialValue: rule.startDate)
         _frequency = State(initialValue: rule.frequency)
         _hasEndDate = State(initialValue: rule.endDate != nil)
         _endDate = State(initialValue: rule.endDate ?? Calendar.current.date(byAdding: .month, value: 1, to: Date.now) ?? Date.now)
-        _timeZoneIdentifier = State(initialValue: rule.recurrenceTimeZoneIdentifier ?? TimeZone.current.identifier)
     }
 
     var body: some View {
         NavigationStack {
-            ExpenseInfoForm(
-                name: $name,
-                amount: $amount,
-                date: .constant(rule.startDate),
-                category: $category,
-                tags: $tags,
-                note: $note
-            )
-
-            Divider()
-                .padding(.horizontal)
-
             ScrollView {
                 VStack(spacing: 12) {
-                    HStack {
-                        Text("Frequency")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Picker("Frequency", selection: $frequency) {
-                            ForEach(RecurrenceFrequency.allCases, id: \.self) { freq in
-                                Text(freq.rawValue).tag(freq)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .tint(.primary)
-                    }
+                    ExpenseInfoForm(
+                        name: $name,
+                        amount: $amount,
+                        date: $startDate,
+                        category: $category,
+                        tags: $tags,
+                        note: $note
+                    )
 
-                    Toggle(isOn: $hasEndDate.animation()) {
-                        Text("End Date")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
+                    Divider()
+                        .padding(.horizontal)
 
-                    if hasEndDate {
-                        DatePicker(
-                            "Ends on",
-                            selection: $endDate,
-                            in: rule.startDate...,
-                            displayedComponents: .date
-                        )
-                        .font(.subheadline)
-                    }
-
-                    if rule.recurrenceTimeZoneIdentifier == nil {
-                        Toggle("Use Fixed Schedule", isOn: $useFixedSchedule)
-                        Text("This existing rule uses each device's calendar and time zone. Monthly dates can drift after a shorter month. Keep this off to leave its scheduling unchanged.")
+                    VStack(spacing: 12) {
+                        Text("Date sets the schedule’s start and repeating day. Changing it or the frequency updates future occurrences only. End date changes only limit when generation stops; extending it allows catch-up on the current schedule.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    }
 
-                    if useFixedSchedule || rule.recurrenceTimeZoneIdentifier != nil {
-                        Picker("Time Zone", selection: $timeZoneIdentifier) {
-                            ForEach(Array(Set(TimeZone.knownTimeZoneIdentifiers + [timeZoneIdentifier, TimeZone.current.identifier])).sorted(), id: \.self) { identifier in
-                                Text(identifier.replacingOccurrences(of: "_", with: " ")).tag(identifier)
+                        HStack {
+                            Text("Frequency")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Picker("Frequency", selection: $frequency) {
+                                ForEach(RecurrenceFrequency.allCases, id: \.self) { freq in
+                                    Text(freq.rawValue).tag(freq)
+                                }
                             }
+                            .pickerStyle(.menu)
+                            .accessibilityIdentifier("recurring-frequency-picker")
+                            .tint(.primary)
                         }
-                        .pickerStyle(.menu)
-                        Text("Uses the Gregorian calendar and this time zone on every device. Monthly dates return to the original start day after shorter months.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+
+                        Toggle(isOn: $hasEndDate.animation()) {
+                            Text("End Date")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if hasEndDate {
+                            DatePicker(
+                                "Ends on",
+                                selection: $endDate,
+                                in: startDate...,
+                                displayedComponents: .date
+                            )
+                            .font(.subheadline)
+                        }
                     }
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
                 }
-                .padding(.horizontal)
-                .padding(.bottom, 8)
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -127,7 +114,11 @@ struct EditRecurringRuleSheet: View {
                 Button("Update Future Schedule") { saveChanges(scheduleConfirmed: true) }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("Use the Gregorian calendar in \(timeZoneIdentifier). Existing expenses and their identities stay unchanged. Past catch-up is skipped. Monthly rules already started resume after this month or the latest recorded occurrence's month, whichever is later. Other frequencies resume after that date on their cadence. Future start dates are kept. Update Syl on every synced device first; older versions do not honor this schedule.")
+                if frequency == .monthly {
+                    Text("Existing expenses stay unchanged. Monthly expenses resume after this month or the latest recorded month, whichever is later. A later start date is kept. No past expenses will be added.")
+                } else {
+                    Text("Existing expenses stay unchanged. The schedule repeats from the selected start date, beginning after today or the latest recorded expense, whichever is later. No past expenses will be added.")
+                }
             }
             .confirmationDialog("Discard changes?", isPresented: $showDiscardConfirmation, titleVisibility: .visible) {
                 Button("Discard Changes", role: .destructive) { dismiss() }
@@ -141,12 +132,15 @@ struct EditRecurringRuleSheet: View {
         .interactiveDismissDisabled(hasChanges)
     }
 
+    private var changesAnchor: Bool {
+        startDate != rule.startDate || frequency != rule.frequency
+    }
+
     private var hasChanges: Bool {
         name != rule.name || amount != rule.amount || note != rule.note || category != rule.category
             || tags.map(\.persistentModelID) != (rule.tags ?? []).map(\.persistentModelID)
-            || frequency != rule.frequency || hasEndDate != (rule.endDate != nil)
+            || startDate != rule.startDate || frequency != rule.frequency || hasEndDate != (rule.endDate != nil)
             || (hasEndDate && endDate != rule.endDate)
-            || useFixedSchedule || timeZoneIdentifier != (rule.recurrenceTimeZoneIdentifier ?? TimeZone.current.identifier)
     }
 
     private func requestDismissal() {
@@ -174,8 +168,13 @@ struct EditRecurringRuleSheet: View {
             return
         }
 
-        let changesSchedule = (rule.recurrenceTimeZoneIdentifier == nil && useFixedSchedule)
-            || (rule.recurrenceTimeZoneIdentifier != nil && rule.recurrenceTimeZoneIdentifier != timeZoneIdentifier)
+        guard !hasEndDate || endDate >= startDate else {
+            errorMessage = "End date must be on or after the start date."
+            showError = true
+            return
+        }
+
+        let changesSchedule = changesAnchor
         if changesSchedule && !scheduleConfirmed {
             showScheduleConfirmation = true
             return
@@ -194,8 +193,14 @@ struct EditRecurringRuleSheet: View {
             showError = true
             return
         }
-        guard let timeZone = TimeZone(identifier: timeZoneIdentifier) else {
-            errorMessage = "Please choose a valid time zone."
+        do {
+            if changesSchedule {
+                try rule.editSchedule(startDate: startDate, frequency: frequency,
+                                      endDate: hasEndDate ? endDate : nil,
+                                      in: .current, after: .now, existingExpenses: existingExpenses)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
             showError = true
             return
         }
@@ -205,11 +210,7 @@ struct EditRecurringRuleSheet: View {
         rule.note = note
         rule.category = category
         rule.tags = tags
-        rule.frequency = frequency
         rule.endDate = hasEndDate ? endDate : nil
-        if changesSchedule {
-            rule.enableFixedSchedule(in: timeZone, after: .now, existingExpenses: existingExpenses)
-        }
 
         do {
             try modelContext.save()

--- a/FinanceTrackerTests/RecurringExpenseServiceTests.swift
+++ b/FinanceTrackerTests/RecurringExpenseServiceTests.swift
@@ -447,6 +447,78 @@ struct RecurringExpenseServiceTests {
         #expect(rule.nextOccurrence() == calendar.date(byAdding: .day, value: 14, to: cursor))
     }
 
+    @Test(arguments: [RecurrenceFrequency.daily, .weekly, .biweekly, .monthly]) @MainActor
+    func scheduleEditReanchorsAndPreservesHistory(frequency: RecurrenceFrequency) throws {
+        let calendar = utcCalendar()
+        func day(_ day: Int, month: Int = 3) throws -> Date {
+            try #require(calendar.date(from: DateComponents(year: 2026, month: month, day: day, hour: 12)))
+        }
+        let container = try SageModelContainer.make(for: .test)
+        let context = container.mainContext
+        let oldStart = try day(1)
+        let anchor = try day(2)
+        let boundary = try day(15)
+        let expected: Date
+        switch frequency {
+        case .daily: expected = try day(16)
+        case .weekly: expected = try day(16)
+        case .biweekly: expected = try day(16)
+        case .monthly: expected = try day(2, month: 4)
+        }
+        let rule = RecurringExpenseRule(name: "Bill", amount: 10, note: "", category: .needs,
+                                        frequency: .daily, startDate: oldStart,
+                                        lastGeneratedDate: oldStart, recurrenceTimeZoneIdentifier: nil)
+        let key = RecurringExpenseOccurrence.key(ruleID: rule.id, scheduledDate: boundary)
+        let expense = Expense(name: "Edited history", amount: 99, date: oldStart,
+                              recurringExpenseId: rule.id, recurringOccurrenceKey: key)
+        context.insert(rule)
+        context.insert(expense)
+        try context.save()
+        try rule.editSchedule(startDate: anchor, frequency: frequency, endDate: expected,
+                              in: calendar.timeZone, after: oldStart, existingExpenses: [expense])
+        try context.save()
+        let reloaded = try #require(ModelContext(container).fetch(FetchDescriptor<RecurringExpenseRule>()).first)
+        #expect(reloaded.startDate == anchor)
+        #expect(reloaded.frequency == frequency)
+        #expect(reloaded.recurrenceEffectiveDate == boundary)
+        #expect(reloaded.recurrenceTimeZoneIdentifier == calendar.timeZone.identifier)
+        #expect(reloaded.lastGeneratedDate == nil)
+        #expect(RecurringExpenseSchedule(rule: reloaded).firstPendingOccurrence() == expected)
+        let service = RecurringExpenseService(modelContext: context)
+        try service.generateAllExpenses(through: expected)
+        let retry = try service.generateAllExpenses(through: expected.addingTimeInterval(86400 * 40))
+        #expect(retry.generatedCount == 0)
+        #expect(try context.fetchCount(FetchDescriptor<Expense>()) == 2)
+        #expect(expense.recurringOccurrenceKey == key)
+        #expect(expense.date == oldStart)
+        #expect(expense.amount == 99)
+        #expect(expense.name == "Edited history")
+    }
+
+    @Test @MainActor
+    func scheduleEditHonorsFutureStartAndRejectsInvalidEndWithoutMutation() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let future = now.addingTimeInterval(86400 * 40)
+        let rule = RecurringExpenseRule(name: "Bill", amount: 10, note: "", category: .needs,
+                                        frequency: .daily, startDate: now, lastGeneratedDate: now)
+        #expect(throws: RecurringScheduleEditError.self) {
+            try rule.editSchedule(startDate: future, frequency: .monthly, endDate: now,
+                                  in: utcCalendar().timeZone, after: now, existingExpenses: [])
+        }
+        #expect(rule.startDate == now)
+        #expect(rule.frequency == .daily)
+        #expect(rule.lastGeneratedDate == now)
+        #expect(rule.recurrenceEffectiveDate == nil)
+        try rule.editSchedule(startDate: future, frequency: .monthly, endDate: nil,
+                              in: utcCalendar().timeZone, after: now, existingExpenses: [])
+        #expect(RecurringExpenseSchedule(rule: rule).firstPendingOccurrence() == future)
+        // A second edit cannot reopen dates before the durable boundary.
+        try rule.editSchedule(startDate: now.addingTimeInterval(-86400), frequency: .daily, endDate: now,
+                              in: utcCalendar().timeZone, after: now.addingTimeInterval(-86400), existingExpenses: [])
+        #expect(rule.recurrenceEffectiveDate == now)
+        #expect(RecurringExpenseSchedule(rule: rule).firstPendingOccurrence() == nil)
+    }
+
     private func utcCalendar() -> Calendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!

--- a/FinanceTrackerUITests/FinanceTrackerUITests.swift
+++ b/FinanceTrackerUITests/FinanceTrackerUITests.swift
@@ -575,6 +575,35 @@ final class FinanceTrackerUITests: XCTestCase {
         assertExpenseAmount(1234.56, in: app)
     }
 
+    func testRecurringScheduleEditRequiresConfirmationAndPersists() {
+        let app = launchApp(seedCalendar: true)
+        tap(app.tabBars.buttons["Settings"], named: "Settings")
+        tap("Recurring Expenses", in: app)
+        tap(app.staticTexts["Calendar Subscription"],
+            named: "Calendar Subscription")
+        let frequency = app.descendants(matching: .any)["recurring-frequency-picker"].firstMatch
+        XCTAssertTrue(scrollToVisibility(of: frequency, in: app))
+        frequency.tap()
+        tap("Weekly", in: app)
+        tap("Save", in: app)
+        let confirmation = app.buttons["Update Future Schedule"]
+        XCTAssertTrue(confirmation.waitForExistence(timeout: timeout))
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Schedule edit confirmation"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        confirmation.tap()
+        let row = app.staticTexts["Calendar Subscription"]
+        XCTAssertTrue(row.waitForExistence(timeout: timeout))
+        row.tap()
+        XCTAssertTrue(scrollToVisibility(of: frequency, in: app))
+        XCTAssertTrue(frequency.label.contains("Weekly"))
+        XCTAssertFalse(app.buttons["Time Zone"].exists)
+        XCTAssertFalse(app.switches["Use Fixed Schedule"].exists)
+        tap("Cancel", in: app)
+        XCTAssertTrue(row.waitForExistence(timeout: timeout))
+    }
+
     func testRecurringReminderSettings() {
         let app = launchApp()
         let settings = app.tabBars.buttons["Settings"]

--- a/SageKit/Services/RecurringExpenseSchedule.swift
+++ b/SageKit/Services/RecurringExpenseSchedule.swift
@@ -95,7 +95,35 @@ public struct RecurringExpenseSchedule {
     }
 }
 
+public enum RecurringScheduleEditError: LocalizedError {
+    case endBeforeStart
+
+    public var errorDescription: String? {
+        "End date must be on or after the start date."
+    }
+}
+
 public extension RecurringExpenseRule {
+    /// Apply only after confirmation; the caller owns saving/rollback with other edits.
+    /// Keeps expense identities and values. Skips catch-up through the latest of now,
+    /// the old cursor, prior boundary and recorded occurrence identities. Monthly rules
+    /// resume in the following month; other frequencies follow the new start's cadence.
+    /// A future start beyond the boundary is the first occurrence. An end before the
+    /// next occurrence leaves the rule inactive. Editing opts legacy rules into a fixed zone.
+    func editSchedule(startDate: Date, frequency: RecurrenceFrequency, endDate: Date?,
+                      in timeZone: TimeZone, after date: Date, existingExpenses: [Expense]) throws {
+        guard endDate.map({ $0 >= startDate }) ?? true else {
+            throw RecurringScheduleEditError.endBeforeStart
+        }
+        enableFixedSchedule(in: timeZone, after: date, existingExpenses: existingExpenses)
+        self.startDate = startDate
+        self.frequency = frequency
+        self.endDate = endDate
+        // The old cursor belongs to the old cadence; its high-water mark is now in
+        // recurrenceEffectiveDate. Start the new cadence from its own anchor.
+        lastGeneratedDate = nil
+    }
+
     /// Call only after explicit confirmation. Does not rewrite expenses, keys or the cursor.
     func enableFixedSchedule(in timeZone: TimeZone, after date: Date, existingExpenses: [Expense]) {
         var boundary = max(date, lastGeneratedDate ?? date)


### PR DESCRIPTION
The recurring editor displayed an interactive date picker whose changes were discarded. It now stages the start date and applies confirmed start/frequency edits through an explicit schedule operation.

- Preserve recorded expenses and occurrence identities, skip past catch-up through a durable boundary, and reanchor future occurrences to the edited start. Monthly schedules resume after the boundary month; other frequencies retain the new start's cadence. Future starts remain eligible, and invalid end dates are rejected before mutation.
- Automatically capture the device's current time zone when editing a schedule; remove the time-zone picker and fixed-schedule toggle. End-only and expense-detail edits keep the existing schedule behavior.
- Make the editor scroll as one form and update the readiness checklist with semantics and remaining device-validation limitations.

Validation: app build and 39 recurrence/reminder-plan tests passed on an iPhone 17 Pro simulator (iOS 26.5). A focused UI regression test covers confirmation, save/reopen, and removal of scheduling configuration controls. `git diff --check` passed. Multi-device concurrent editing and older-client compatibility have not been device-validated.

Closes #59
